### PR TITLE
Update GitHub Actions runners from Ubuntu 24 to Ubuntu 22 for both am…

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,10 +18,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - runner: ubuntu24-4cpu-amd64
+          - runner: ubuntu22-4cpu-amd64
             platform: linux-amd64
             arch: x64
-          - runner: ubuntu24-4cpu-arm64
+          - runner: ubuntu22-4cpu-arm64
             platform: linux-arm64
             arch: aarch64
           - runner: macos-latest


### PR DESCRIPTION
…d64 and arm64 architectures in build workflow.

## Summary
Root Cause: The Linux builds were using Ubuntu 24 runners which have GLIBC 2.39. When users run the binary on systems with older GLIBC (like GLIBC 2.35 or 2.38), they get the error GLIBC_2.38' not found.

## Fix: Changed the Linux runners from ubuntu24-* to ubuntu22-*:
ubuntu24-4cpu-amd64 → ubuntu22-4cpu-amd64
ubuntu24-4cpu-arm64 → ubuntu22-4cpu-arm64
Ubuntu 22.04 has GLIBC 2.35, which provides much better compatibility with a wider range of Linux distributions.

## Testing: Built and tested the binary locally on this Linux ARM64 machine:
✅ Build completed successfully with GLIBC 2.35
✅ Binary runs without GLIBC errors
✅ Tarball creation and extraction works
✅ lumos --version outputs lumos version 2.1.2
