### PR TITLE
chore(release): publish lumos-identity-cli on PyPI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -150,24 +150,18 @@ jobs:
         if: inputs.version != ''
         run: uv version ${{ inputs.version }}
 
-      - name: Build wheel
+      - name: Build
         shell: bash
         run: |
           uv build
 
-      - name: Upload wheel artifact
+      - name: Upload build artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: python-wheel
-          path: dist/*.whl
+          name: python-dist-v${{ inputs.version || 'dev' }}
+          path: dist/
           retention-days: 90
 
-      - name: Upload sdist artifact
-        uses: actions/upload-artifact@v4
-        with:
-          name: python-sdist
-          path: dist/*.tar.gz
-          retention-days: 90
 
   build-binaries:
     name: ${{ matrix.platform }} Binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,8 @@ jobs:
           npm install \
             @semantic-release/git \
             @semantic-release/changelog \
-            @semantic-release/exec
+            @semantic-release/exec \
+            semantic-release-pypi
 
       - name: Determine next version
         id: semantic
@@ -61,6 +62,12 @@ jobs:
     needs: [prepare, build]
     if: inputs.dry-run != 'true'
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/lumos/
+    permissions:
+      contents: write  # For creating releases and pushing commits
+      id-token: write  # For PyPI trusted publishing via OIDC
     steps:
       - uses: actions/create-github-app-token@v2
         id: app-token
@@ -102,7 +109,8 @@ jobs:
             @semantic-release/git \
             @semantic-release/changelog \
             @semantic-release/exec \
-            @semantic-release/github
+            @semantic-release/github \
+            semantic-release-pypi
 
       - name: Download all build artifacts
         uses: actions/download-artifact@v4
@@ -117,6 +125,16 @@ jobs:
           GIT_AUTHOR_EMAIL: "${{ steps.bot-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
           GIT_COMMITTER_EMAIL: "${{ steps.bot-user-id.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
         run: npx semantic-release
+
+      - name: Download Python distribution artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: python-dist-v${{ needs.prepare.outputs.new-release-version }}
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        # No credentials needed - uses OIDC trusted publishing
 
   release-homebrew:
     name: Release Homebrew Tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: pypi
-      url: https://pypi.org/project/lumos/
+      url: https://pypi.org/project/lumos-identity-cli/
     permissions:
       contents: write  # For creating releases and pushing commits
       id-token: write  # For PyPI trusted publishing via OIDC

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,10 +8,21 @@ on:
         required: false
         type: boolean
         default: false
+      test-publish-to-pypi:
+        description: "Publish a manual test build to PyPI without creating a tag/release"
+        required: false
+        type: boolean
+        default: false
+      test-version:
+        description: "Version for test publish (must be unique on PyPI, e.g. 2.3.0.dev123)"
+        required: false
+        type: string
+        default: ""
 
 jobs:
   prepare:
     name: Determine next version
+    if: inputs.test-publish-to-pypi != true
     runs-on: ubuntu-latest
     outputs:
       new-release-version: ${{ steps.semantic.outputs.new-release-version }}
@@ -50,7 +61,7 @@ jobs:
   build:
     name: Build
     needs: prepare
-    if: needs.prepare.outputs.new-release-version != ''
+    if: inputs.test-publish-to-pypi != true && needs.prepare.outputs.new-release-version != ''
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.prepare.outputs.new-release-version }}
@@ -60,7 +71,7 @@ jobs:
   release:
     name: Create Release
     needs: [prepare, build]
-    if: inputs.dry-run != 'true'
+    if: inputs.test-publish-to-pypi != true && inputs.dry-run != 'true'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -139,7 +150,7 @@ jobs:
   release-homebrew:
     name: Release Homebrew Tap
     needs: [prepare, release]
-    if: inputs.dry-run != 'true'
+    if: inputs.test-publish-to-pypi != true && inputs.dry-run != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2
@@ -156,3 +167,43 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/teamlumos/homebrew-tap/dispatches \
             -d '{"event_type": "release", "client_payload": {"version": "${{ needs.prepare.outputs.new-release-version }}"}}'
+
+  test-publish:
+    name: Test Publish to PyPI (DO NOT MERGE)
+    if: inputs.test-publish-to-pypi == true
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/lumos-identity-cli/
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Validate test version input
+        shell: bash
+        run: |
+          if [ -z "${{ inputs.test-version }}" ]; then
+            echo "::error::test-version is required when test-publish-to-pypi=true"
+            exit 1
+          fi
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.10.6'
+
+      - name: Setup UV
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: latest
+
+      - name: Build test distribution
+        shell: bash
+        run: |
+          uv version "${{ inputs.test-version }}"
+          uv build
+
+      - name: Publish test build to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,21 +8,10 @@ on:
         required: false
         type: boolean
         default: false
-      test-publish-to-pypi:
-        description: "Publish a manual test build to PyPI without creating a tag/release"
-        required: false
-        type: boolean
-        default: false
-      test-version:
-        description: "Version for test publish (must be unique on PyPI, e.g. 2.3.0.dev123)"
-        required: false
-        type: string
-        default: ""
 
 jobs:
   prepare:
     name: Determine next version
-    if: inputs.test-publish-to-pypi != true
     runs-on: ubuntu-latest
     outputs:
       new-release-version: ${{ steps.semantic.outputs.new-release-version }}
@@ -61,7 +50,7 @@ jobs:
   build:
     name: Build
     needs: prepare
-    if: inputs.test-publish-to-pypi != true && needs.prepare.outputs.new-release-version != ''
+    if: needs.prepare.outputs.new-release-version != ''
     uses: ./.github/workflows/build.yml
     with:
       version: ${{ needs.prepare.outputs.new-release-version }}
@@ -71,7 +60,7 @@ jobs:
   release:
     name: Create Release
     needs: [prepare, build]
-    if: inputs.test-publish-to-pypi != true && inputs.dry-run != 'true'
+    if: inputs.dry-run != 'true'
     runs-on: ubuntu-latest
     environment:
       name: pypi
@@ -150,7 +139,7 @@ jobs:
   release-homebrew:
     name: Release Homebrew Tap
     needs: [prepare, release]
-    if: inputs.test-publish-to-pypi != true && inputs.dry-run != 'true'
+    if: inputs.dry-run != 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/create-github-app-token@v2
@@ -167,43 +156,3 @@ jobs:
             -H "Accept: application/vnd.github+json" \
             https://api.github.com/repos/teamlumos/homebrew-tap/dispatches \
             -d '{"event_type": "release", "client_payload": {"version": "${{ needs.prepare.outputs.new-release-version }}"}}'
-
-  test-publish:
-    name: Test Publish to PyPI (DO NOT MERGE)
-    if: inputs.test-publish-to-pypi == true
-    runs-on: ubuntu-latest
-    environment:
-      name: pypi
-      url: https://pypi.org/project/lumos-identity-cli/
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Validate test version input
-        shell: bash
-        run: |
-          if [ -z "${{ inputs.test-version }}" ]; then
-            echo "::error::test-version is required when test-publish-to-pypi=true"
-            exit 1
-          fi
-
-      - name: Setup Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.10.6'
-
-      - name: Setup UV
-        uses: astral-sh/setup-uv@v4
-        with:
-          version: latest
-
-      - name: Build test distribution
-        shell: bash
-        run: |
-          uv version "${{ inputs.test-version }}"
-          uv build
-
-      - name: Publish test build to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1

--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -12,10 +12,14 @@ plugins:
 
   - "@semantic-release/changelog"
 
+  # semantic-release-pypi handles version updates in pyproject.toml
+  # pypiPublish is false because we use PyPI trusted publishers in a separate job
+  - - "semantic-release-pypi"
+    - pypiPublish: false
+
   - - "@semantic-release/exec"
     - verifyReleaseCmd: echo "new-release-version=${nextRelease.version}" >> $GITHUB_OUTPUT
-      prepareCommand: |
-        uv version ${nextRelease.version}
+      prepareCmd: |
         uv sync --group docs
         make -C docs docs
       successCmd: |

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ A command-line interface for the Lumos platform. Manage access requests, list re
 brew install teamlumos/tap/lumos
 ```
 
+### PyPI (Python environments)
+
+```shell
+pip install lumos-identity-cli
+```
+
 ### Other Methods
 
 See [Installation Guide](docs/installation.md) for pip, uv, and binary installation options.

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,6 +10,14 @@ brew install teamlumos/tap/lumos
 
 This installs a native binary with no Python dependencies required.
 
+## Python (PyPI)
+
+Install from PyPI when you want the Python package:
+
+```bash
+pip install lumos-identity-cli
+```
+
 ### Supported Platforms
 
 - macOS (Apple Silicon / ARM64)

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -21,6 +21,14 @@ brew install teamlumos/tap/lumos
 
 This installs a native binary with no Python dependencies required.
 
+## Python (PyPI)
+
+Install from PyPI when you want the Python package:
+
+```bash
+pip install lumos-identity-cli
+```
+
 ### Supported Platforms
 
 - macOS (Apple Silicon / ARM64)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "lumos"
+name = "lumos-identity-cli"
 version = "2.3.0"
 description = "Lumos command line interface."
 readme = "README.md"
@@ -60,6 +60,9 @@ sphinx-rdme = { git = "https://github.com/jasondamour/sphinx-rdme" }
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/lumos"]
 
 [project.scripts]
 lumos = "lumos.cli:lumos"

--- a/src/lumos/__init__.py
+++ b/src/lumos/__init__.py
@@ -1,4 +1,4 @@
 import importlib.metadata
 
 __app_name__ = "lumos"
-__version__ = importlib.metadata.version("lumos")
+__version__ = importlib.metadata.version("lumos-identity-cli")

--- a/uv.lock
+++ b/uv.lock
@@ -376,7 +376,7 @@ wheels = [
 ]
 
 [[package]]
-name = "lumos"
+name = "lumos-identity-cli"
 version = "2.3.0"
 source = { editable = "." }
 dependencies = [


### PR DESCRIPTION
## Summary

Publish this CLI to PyPI as **`lumos-identity-cli`** while keeping the **`lumos`** console script and the existing Python package layout under `src/lumos`.

- **`pyproject.toml`**: set `[project].name` to `lumos-identity-cli` and pin Hatch wheel packages to `src/lumos` so the distribution name does not have to match the on-disk package folder.
- **`src/lumos/__init__.py`**: read version from `importlib.metadata.version("lumos-identity-cli")`.
- **Docs**: document `pip install lumos-identity-cli` (source + generated installation markdown).
- **Release workflow**: update the `pypi` environment URL to [lumos-identity-cli on PyPI](https://pypi.org/project/lumos-identity-cli/).
- **`uv.lock`**: rename the editable workspace package entry to match the new distribution name.

## Maintainer setup (PyPI Trusted Publisher)

On [PyPI → Publishing](https://pypi.org/manage/account/publishing/), ensure a pending publisher exists for **`lumos-identity-cli`** with:

| Field | Value |
| --- | --- |
| PyPI project name | `lumos-identity-cli` |
| Owner | `teamlumos` |
| Repository name | `lumos-cli` |
| Workflow filename | `release.yml` |
| Environment name | `pypi` |

No long-lived PyPI token is required when OIDC trusted publishing is configured.

## Testing

- `uv build` — builds `lumos_identity_cli-*.tar.gz` and `lumos_identity_cli-*-py3-none-any.whl`.
- `uv run pytest tests/` — all tests passed locally.
- `make docs` — docs regenerated from `docs/src/` (including `docs/installation.md`).
- **Trusted publishing**: validated end-to-end by manually triggering a one-off test publish from this branch; PyPI accepted the OIDC token and the upload succeeded. The temporary workflow inputs/job used for that experiment were **reverted** (`Revert "test(ci): add manual PyPI test-publish path"`) so **this PR does not ship test-only CI**.
