### PR TITLE
ci(release): fix docs build commands in semantic-release

### DIFF
--- a/.releaserc.yaml
+++ b/.releaserc.yaml
@@ -21,11 +21,11 @@ plugins:
     - verifyReleaseCmd: echo "new-release-version=${nextRelease.version}" >> $GITHUB_OUTPUT
       prepareCmd: |
         uv sync --group docs
-        make -C docs docs
+        make docs
       successCmd: |
         export DEBUG=rdme*
         echo "Publishing documentation to readme.io..."
-        rdme docs docs/src/_build/readme-io
+        rdme docs docs/src/_build/rdme
         echo "✅ Documentation published to readme.io"
 
   - - "@semantic-release/git"


### PR DESCRIPTION
Update semantic-release docs commands to use the repo-root Makefile and the current rdme output path so release no longer fails during prepare/success steps.