### PR TITLE
fix(cli): use click-extra version_fields for PyPI installs

### DIFF
--- a/.cursor/rules/docs.mdc
+++ b/.cursor/rules/docs.mdc
@@ -26,7 +26,7 @@ Only edit documentation in these locations:
 After editing any files in `docs/src/`, rebuild the documentation:
 
 ```bash
-make -C docs docs
+make docs
 ```
 
 This generates:
@@ -66,4 +66,4 @@ When editing `docs/src/*.md`:
 - Follow existing formatting conventions
 - Use proper Sphinx/MyST markdown syntax
 - Include cross-references where appropriate
-- Always rebuild with `make -C docs docs` after changes
+- Always rebuild with `make docs` after changes

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Check for uncommitted documentation changes
         run: |
           if [ -n "$(git status --porcelain docs/)" ]; then
-            echo "::error::Generated documentation is out of date. Please run 'make -C docs docs' and commit the changes."
+            echo "::error::Generated documentation is out of date. Please run 'make docs' and commit the changes."
             echo ""
             echo "The following files have uncommitted changes:"
             git status --porcelain docs/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -209,7 +209,7 @@ jobs:
       - name: Build binary
         shell: bash
         run: |
-          uv run pyinstaller src/lumos/__main__.py --name lumos
+          uv run pyinstaller src/lumos/__main__.py --name lumos --collect-data click_extra
           VERSION="${{ inputs.version || 'dev' }}"
           tar -czf lumos-${{ matrix.platform }}-v${VERSION}.tar.gz -C ./dist/lumos .
 

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ markdown:
 	@echo "Build finished. The Markdown files are in $(BUILDDIR)/markdown."
 	@cp $(BUILDDIR)/markdown/*.md $(GIT_ROOT)/docs/
 	@echo "Markdown files copied to docs/"
+	@# Normalize platform-specific config paths so docs/reference.md matches Linux CI.
+	@perl -i -pe 's{~/Library/Application Support/lumos}{~/.config/lumos}g' $(GIT_ROOT)/docs/reference.md
 
 # Generate rdme documentation with YAML frontmatter
 rdme:

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -253,7 +253,7 @@ uv version X.Y.Z
 
 # Build artifacts
 uv build
-uv run pyinstaller src/lumos/__main__.py
+uv run pyinstaller src/lumos/__main__.py --collect-data click_extra
 
 # Create and push tag
 git tag vX.Y.Z

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -165,11 +165,11 @@ Documentation is built using [Sphinx](https://www.sphinx-doc.org/) with [MyST Ma
 uv sync --group docs
 
 # Build both HTML and Markdown, copy markdown to docs/
-make -C docs docs
+make docs
 
 # Or build individually:
-make -C docs html      # HTML only
-make -C docs markdown  # Markdown only
+make html      # HTML only
+make markdown  # Markdown only
 
 # View the HTML docs
 open docs/src/_build/html/index.html

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -375,7 +375,7 @@ lumos list apps --csv > apps.csv
 All `list` commands support multiple output formats:
 
 | Format  | Flag        | Use Case                       |
-| ------- | ----------- | ------------------------------ |
+|:--------|:------------|:-------------------------------|
 | Table   | (default)   | Human-readable terminal output |
 | JSON    | `--json`    | Scripting and API integration  |
 | CSV     | `--csv`     | Spreadsheet import/export      |

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -10,13 +10,19 @@ brew install teamlumos/tap/lumos
 
 This installs a native binary with no Python dependencies required.
 
-## Python (PyPI)
+## Python (via PyPI)
 
-Install from PyPI when you want the Python package:
+Install the CLI from [PyPI](https://pypi.org/project/lumos-identity-cli/) with pip or uv:
 
 ```bash
 pip install lumos-identity-cli
 ```
+
+```bash
+uv tool install lumos-identity-cli
+```
+
+Requires Python 3.10.6 or newer. After installation, run `lumos --version` to verify.
 
 ### Supported Platforms
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -30,7 +30,7 @@ pip install lumos-identity-cli
 Download pre-built binaries directly from the [GitHub Releases page](https://github.com/teamlumos/lumos-cli/releases):
 
 | Platform | Architecture          | Download                          |
-| -------- | --------------------- | --------------------------------- |
+|:---------|:----------------------|:----------------------------------|
 | Linux    | AMD64 (x86_64)        | `lumos-linux-amd64-vX.X.X.tar.gz` |
 | Linux    | ARM64                 | `lumos-linux-arm64-vX.X.X.tar.gz` |
 | macOS    | ARM64 (Apple Silicon) | `lumos-macos-arm64-vX.X.X.tar.gz` |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,322 +6,51 @@ This page provides a complete reference for all Lumos CLI commands.
 
 You can get help for any command by using the `--help` flag:
 
-```ansi-shell-session
-$ lumos --no-color --help
-Usage: lumos [OPTIONS] COMMAND [ARGS]...
-
-  Lumos CLI - Command line interface for Lumos
-
-Options:
-  --time / --no-time    Measure and print elapsed execution time.  [default: no-
-                        time]
-  --color, --ansi / --no-color, --no-ansi
-                        Strip out all colors and all ANSI codes from output.
-                        [default: color]
-  --config CONFIG_PATH  Location of the configuration file. Supports local path
-                        with glob patterns or remote URL.  [default:
-                        ~/.config/lumos/*.toml|*.yaml|*.yml|*.json|*.ini]
-  --no-config           Ignore all configuration files and only use command line
-                        parameters and environment variables.
-  --show-params         Show all CLI parameters, their provenance, defaults and
-                        value, then exit.
-  --table-format [asciidoc|csv|csv-excel|csv-excel-tab|csv-unix|double-grid|double-outline|fancy-grid|fancy-outline|github|grid|heavy-grid|heavy-outline|html|jira|latex|latex-booktabs|latex-longtable|latex-raw|mediawiki|mixed-grid|mixed-outline|moinmoin|orgtbl|outline|pipe|plain|presto|pretty|psql|rounded-grid|rounded-outline|rst|simple|simple-grid|simple-outline|textile|tsv|unsafehtml|vertical|youtrack]
-                        Rendering style of tables.  [default: rounded-outline]
-  --verbosity LEVEL     Either CRITICAL, ERROR, WARNING, INFO, DEBUG.  [default:
-                        WARNING]
-  -v, --verbose         Increase the default WARNING verbosity by one level for
-                        each additional repetition of the option.  [default: 0]
-  --version             Show the version and exit.
-  -h, --help            Show this message and exit.
-
-Commands:
-  list     List various Lumos resources
-  login    Login to your Lumos account via OAuth.
-  logout   Logout of your Lumos account.
-  request  Request access to an app.
-  setup    Setup your Lumos CLI.
-  whoami   Show information about the currently logged in user.
-```
-
 ## Authentication Commands
 
 ### `lumos whoami`
 
 Show information about the currently logged in user.
 
-```ansi-shell-session
-$ lumos --no-color whoami --help
-Usage: lumos whoami [OPTIONS]
-
-  Show information about the currently logged in user.
-
-Options:
-  --username  Show the current user's username only
-  --id        Show the current user's ID only
-  -h, --help  Show this message and exit.
-```
-
 ### `lumos setup`
 
 Setup your Lumos CLI authentication. Can be used to login or change your authentication method.
-
-```ansi-shell-session
-$ lumos --no-color setup --help
-Usage: lumos setup [OPTIONS]
-
-  Setup your Lumos CLI. Can be used to login or change your authentication
-  method.
-
-Options:
-  -h, --help  Show this message and exit.
-```
 
 ### `lumos login`
 
 Login to your Lumos account via OAuth. You must be logged in to Lumos on your browser.
 
-```ansi-shell-session
-$ lumos --no-color login --help
-Usage: lumos login [OPTIONS]
-
-  Login to your Lumos account via OAuth. You must be logged in to Lumos on your
-  browser.
-
-Options:
-  --admin     Log in as an admin, if you have the permission to do so
-  -h, --help  Show this message and exit.
-```
-
 ### `lumos logout`
 
 Logout of your Lumos account and clear stored credentials.
-
-```ansi-shell-session
-$ lumos --no-color logout --help
-Usage: lumos logout [OPTIONS]
-
-  Logout of your Lumos account.
-
-Options:
-  -h, --help  Show this message and exit.
-```
 
 ## List Commands
 
 The `list` command group provides access to various Lumos resources.
 
-```ansi-shell-session
-$ lumos --no-color list --help
-Usage: lumos list [OPTIONS] COMMAND [ARGS]...
-
-  List various Lumos resources
-
-Options:
-  --time / --no-time    Measure and print elapsed execution time.  [default: no-
-                        time]
-  --color, --ansi / --no-color, --no-ansi
-                        Strip out all colors and all ANSI codes from output.
-                        [default: color]
-  --config CONFIG_PATH  Location of the configuration file. Supports local path
-                        with glob patterns or remote URL.  [default:
-                        ~/.config/lumos/*.toml|*.yaml|*.yml|*.json|*.ini]
-  --no-config           Ignore all configuration files and only use command line
-                        parameters and environment variables.
-  --show-params         Show all CLI parameters, their provenance, defaults and
-                        value, then exit.
-  --table-format [asciidoc|csv|csv-excel|csv-excel-tab|csv-unix|double-grid|double-outline|fancy-grid|fancy-outline|github|grid|heavy-grid|heavy-outline|html|jira|latex|latex-booktabs|latex-longtable|latex-raw|mediawiki|mixed-grid|mixed-outline|moinmoin|orgtbl|outline|pipe|plain|presto|pretty|psql|rounded-grid|rounded-outline|rst|simple|simple-grid|simple-outline|textile|tsv|unsafehtml|vertical|youtrack]
-                        Rendering style of tables.  [default: rounded-outline]
-  --verbosity LEVEL     Either CRITICAL, ERROR, WARNING, INFO, DEBUG.  [default:
-                        WARNING]
-  -v, --verbose         Increase the default WARNING verbosity by one level for
-                        each additional repetition of the option.  [default: 0]
-  --version             Show the version and exit.
-  -h, --help            Show this message and exit.
-
-Commands:
-  apps         List apps in the appstore
-  groups       List groups for the domain or the specified --app
-  permissions  List permissions for a given app
-  requests     List access requests
-  users        List users in Lumos
-```
-
 ### `lumos list apps`
 
 List apps available in the appstore.
-
-```ansi-shell-session
-$ lumos list --no-color apps --help
-Usage: lumos list apps [OPTIONS]
-
-  List apps in the appstore
-
-Options:
-  --like TEXT                 Filters apps by search term
-  --mine                      Show only my apps.
-  --csv                       Output as CSV
-  --json                      Output as JSON
-  --paginate / --no-paginate  Pagination  [default: paginate]
-  --page-size INTEGER         Page size  [default: 100]
-  --page INTEGER              Page  [default: 1]
-  --id-only                   Output ID only
-  -h, --help                  Show this message and exit.
-```
 
 ### `lumos list users`
 
 List users in Lumos.
 
-```ansi-shell-session
-$ lumos list --no-color users --help
-Usage: lumos list users [OPTIONS]
-
-  List users in Lumos
-
-Options:
-  --like TEXT                 Search by name or email
-  --csv                       Output as CSV
-  --json                      Output as JSON
-  --paginate / --no-paginate  Pagination  [default: paginate]
-  --page-size INTEGER         Page size  [default: 100]
-  --page INTEGER              Page  [default: 1]
-  --id-only                   Output ID only
-  -h, --help                  Show this message and exit.
-```
-
 ### `lumos list permissions`
 
 List permissions for a given app.
-
-```ansi-shell-session
-$ lumos list --no-color permissions --help
-Usage: lumos list permissions [OPTIONS]
-
-  List permissions for a given app
-
-Options:
-  --app TEXT                  App UUID  [required]
-  --like TEXT                 Filters permissions
-  --csv                       Output as CSV
-  --json                      Output as JSON
-  --paginate / --no-paginate  Pagination  [default: paginate]
-  --page-size INTEGER         Page size  [default: 100]
-  --page INTEGER              Page  [default: 1]
-  --id-only                   Output ID only
-  -h, --help                  Show this message and exit.
-```
 
 ### `lumos list groups`
 
 List groups for the domain or a specific app.
 
-```ansi-shell-session
-$ lumos list --no-color groups --help
-Usage: lumos list groups [OPTIONS]
-
-  List groups for the domain or the specified --app
-
-Options:
-  --app TEXT                  App ID to filter groups by. If not provided, lists
-                              all groups.
-  --like TEXT                 Filters groups
-  --csv                       Output as CSV
-  --json                      Output as JSON
-  --paginate / --no-paginate  Pagination  [default: paginate]
-  --page-size INTEGER         Page size  [default: 100]
-  --page INTEGER              Page  [default: 1]
-  --id-only                   Output ID only
-  -h, --help                  Show this message and exit.
-```
-
 ### `lumos list requests`
 
 List access requests.
 
-```ansi-shell-session
-$ lumos list --no-color requests --help
-Usage: lumos list requests [OPTIONS]
-
-  List access requests
-
-Options:
-  --for-user TEXT             Show only requests for ('targetting') a particular
-                              user
-  --mine                      Show only requests for ('targetting') me. Takes
-                              precedence over --for-user.
-  --status TEXT               One of `PENDING`, `COMPLETED`,
-                              `DENIED_PROVISIONING`, etc
-  --pending                   Show only pending requests
-  --past                      Show only past requests
-  --csv                       Output as CSV
-  --json                      Output as JSON
-  --paginate / --no-paginate  Pagination  [default: paginate]
-  --page-size INTEGER         Page size  [default: 100]
-  --page INTEGER              Page  [default: 1]
-  --id-only                   Output ID only
-  -h, --help                  Show this message and exit.
-```
-
 ## Request Commands
 
 The `request` command group handles access requests.
-
-```ansi-shell-session
-$ lumos --no-color request --help
-Usage: lumos request [OPTIONS] COMMAND [ARGS]...
-
-  Request access to an app.
-
-Options:
-  --reason TEXT           Business justification for request
-  --for-user TEXT         UUID of user for whom to request access. Takes
-                          precedence over --user-like
-  --for-me                Makes the request for the current user.
-  --mine                  Makes the request for the current user. Duplicate of
-                          --for-me for convenience.
-  --app TEXT              App UUID. Takes precedence over --app-like
-  --permission TEXT       List of permission UUIDs. Takes precedence over
-                          --permission-like
-  --length TEXT           Length of access request in seconds, or a string like
-                          '12 hours', '2d', 'unlimited', etc. Every
-                          app/permission has different configurations.
-  --user-like TEXT        User name/email like--filters users shown as options
-                          when selecting, if the request is not for the current
-                          user
-  --app-like TEXT         App name like--filters apps shown as options when
-                          selecting
-  --permission-like TEXT  Permission name like--filters permissions shown as
-                          options when selecting
-  --wait / --no-wait      Wait for the request to complete
-  --dry-run               Print the request command without actually making the
-                          request
-  --time / --no-time      Measure and print elapsed execution time.  [default:
-                          no-time]
-  --color, --ansi / --no-color, --no-ansi
-                          Strip out all colors and all ANSI codes from output.
-                          [default: color]
-  --config CONFIG_PATH    Location of the configuration file. Supports local
-                          path with glob patterns or remote URL.  [default:
-                          ~/.config/lumos/*.toml|*.yaml|*.yml|*.json|*.ini]
-  --no-config             Ignore all configuration files and only use command
-                          line parameters and environment variables.
-  --show-params           Show all CLI parameters, their provenance, defaults
-                          and value, then exit.
-  --table-format [asciidoc|csv|csv-excel|csv-excel-tab|csv-unix|double-grid|double-outline|fancy-grid|fancy-outline|github|grid|heavy-grid|heavy-outline|html|jira|latex|latex-booktabs|latex-longtable|latex-raw|mediawiki|mixed-grid|mixed-outline|moinmoin|orgtbl|outline|pipe|plain|presto|pretty|psql|rounded-grid|rounded-outline|rst|simple|simple-grid|simple-outline|textile|tsv|unsafehtml|vertical|youtrack]
-                          Rendering style of tables.  [default: rounded-outline]
-  --verbosity LEVEL       Either CRITICAL, ERROR, WARNING, INFO, DEBUG.
-                          [default: WARNING]
-  -v, --verbose           Increase the default WARNING verbosity by one level
-                          for each additional repetition of the option.
-                          [default: 0]
-  --version               Show the version and exit.
-  -h, --help              Show this message and exit.
-
-Commands:
-  cancel  Cancel a request by ID
-  poll    Poll a request by ID for up to 5 minutes
-  status  Check the status of a request by ID or `--last` for the most recent...
-```
 
 ### `lumos request status`
 
@@ -330,7 +59,7 @@ Check the status of a request by ID or use `--last` for the most recent request.
 **Options:**
 
 | Flag                | Description            |
-| ------------------- | ---------------------- |
+|:--------------------|:-----------------------|
 | `--request-id`      | Request ID to check    |
 | `--last`            | Get the last request   |
 | `--status-only`     | Output status only     |
@@ -344,7 +73,7 @@ Poll a request by ID for up to 5 minutes, waiting for completion.
 **Options:**
 
 | Flag           | Description                      |
-| -------------- | -------------------------------- |
+|:---------------|:---------------------------------|
 | `--request-id` | Request ID to poll               |
 | `--wait`       | How many minutes to wait (max 5) |
 
@@ -355,6 +84,6 @@ Cancel a pending request.
 **Options:**
 
 | Flag           | Description             |
-| -------------- | ----------------------- |
+|:---------------|:------------------------|
 | `--request-id` | Request ID to cancel    |
 | `--reason`     | Reason for cancellation |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,51 +6,339 @@ This page provides a complete reference for all Lumos CLI commands.
 
 You can get help for any command by using the `--help` flag:
 
+```ansi-shell-session
+$ lumos --no-color --help
+Usage: lumos [OPTIONS] COMMAND [ARGS]...
+
+  Lumos CLI - Command line interface for Lumos
+
+Options:
+  --time / --no-time      Measure and print elapsed execution time.  [default:
+                          no-time]
+  --config CONFIG_PATH    Location of the configuration file. Supports local
+                          path with glob patterns or remote URL.  [default: ~/.c
+                          onfig/lumos/{*.toml,*.yaml,*.yml,*.json,*.ini,pyprojec
+                          t.toml}]
+  --no-config             Ignore all configuration files and only use command
+                          line parameters and environment variables.
+  --validate-config FILE  Validate the configuration file and exit.
+  --color, --ansi / --no-color, --no-ansi
+                          Strip out all colors and all ANSI codes from output.
+                          [default: color]
+  --theme [dark|dracula|light|monokai|nord|solarized_dark]
+                          Color theme used for help screens.  [default: dark]
+  --show-params           Show all CLI parameters, their provenance, defaults
+                          and value, then exit.
+  --table-format [aligned|asciidoc|colon-grid|csv|csv-excel|csv-excel-tab|csv-unix|double-grid|double-outline|fancy-grid|fancy-outline|github|grid|heavy-grid|heavy-outline|hjson|html|jira|json|json5|jsonc|latex|latex-booktabs|latex-longtable|latex-raw|mediawiki|mixed-grid|mixed-outline|moinmoin|orgtbl|outline|pipe|plain|presto|pretty|psql|rounded-grid|rounded-outline|rst|simple|simple-grid|simple-outline|textile|toml|tsv|unsafehtml|vertical|xml|yaml|youtrack]
+                          Rendering style of tables.  [default: rounded-outline]
+  --verbosity LEVEL       Either CRITICAL, ERROR, WARNING, INFO, DEBUG.
+                          [default: WARNING]
+  -v, --verbose           Increase the default WARNING verbosity by one level
+                          for each additional repetition of the option.
+                          [default: 0]
+  --version               Show the version and exit.
+  -h, --help              Show this message and exit.
+
+Commands:
+  help     Show help for a command.
+  list     List various Lumos resources
+  login    Login to your Lumos account via OAuth.
+  logout   Logout of your Lumos account.
+  request  Request access to an app.
+  setup    Setup your Lumos CLI.
+  whoami   Show information about the currently logged in user.
+```
+
 ## Authentication Commands
 
 ### `lumos whoami`
 
 Show information about the currently logged in user.
 
+```ansi-shell-session
+$ lumos --no-color whoami --help
+Usage: lumos whoami [OPTIONS]
+
+  Show information about the currently logged in user.
+
+Options:
+  --username  Show the current user's username only
+  --id        Show the current user's ID only
+  -h, --help  Show this message and exit.
+```
+
 ### `lumos setup`
 
 Setup your Lumos CLI authentication. Can be used to login or change your authentication method.
+
+```ansi-shell-session
+$ lumos --no-color setup --help
+Usage: lumos setup [OPTIONS]
+
+  Setup your Lumos CLI. Can be used to login or change your authentication
+  method.
+
+Options:
+  -h, --help  Show this message and exit.
+```
 
 ### `lumos login`
 
 Login to your Lumos account via OAuth. You must be logged in to Lumos on your browser.
 
+```ansi-shell-session
+$ lumos --no-color login --help
+Usage: lumos login [OPTIONS]
+
+  Login to your Lumos account via OAuth. You must be logged in to Lumos on your
+  browser.
+
+Options:
+  --admin     Log in as an admin, if you have the permission to do so
+  -h, --help  Show this message and exit.
+```
+
 ### `lumos logout`
 
 Logout of your Lumos account and clear stored credentials.
+
+```ansi-shell-session
+$ lumos --no-color logout --help
+Usage: lumos logout [OPTIONS]
+
+  Logout of your Lumos account.
+
+Options:
+  -h, --help  Show this message and exit.
+```
 
 ## List Commands
 
 The `list` command group provides access to various Lumos resources.
 
+```ansi-shell-session
+$ lumos --no-color list --help
+Usage: lumos list [OPTIONS] COMMAND [ARGS]...
+
+  List various Lumos resources
+
+Options:
+  --time / --no-time      Measure and print elapsed execution time.  [default:
+                          no-time]
+  --config CONFIG_PATH    Location of the configuration file. Supports local
+                          path with glob patterns or remote URL.  [default: ~/.c
+                          onfig/lumos/{*.toml,*.yaml,*.yml,*.json,*.ini,pyprojec
+                          t.toml}]
+  --no-config             Ignore all configuration files and only use command
+                          line parameters and environment variables.
+  --validate-config FILE  Validate the configuration file and exit.
+  --color, --ansi / --no-color, --no-ansi
+                          Strip out all colors and all ANSI codes from output.
+                          [default: color]
+  --theme [dark|dracula|light|monokai|nord|solarized_dark]
+                          Color theme used for help screens.  [default: dark]
+  --show-params           Show all CLI parameters, their provenance, defaults
+                          and value, then exit.
+  --table-format [aligned|asciidoc|colon-grid|csv|csv-excel|csv-excel-tab|csv-unix|double-grid|double-outline|fancy-grid|fancy-outline|github|grid|heavy-grid|heavy-outline|hjson|html|jira|json|json5|jsonc|latex|latex-booktabs|latex-longtable|latex-raw|mediawiki|mixed-grid|mixed-outline|moinmoin|orgtbl|outline|pipe|plain|presto|pretty|psql|rounded-grid|rounded-outline|rst|simple|simple-grid|simple-outline|textile|toml|tsv|unsafehtml|vertical|xml|yaml|youtrack]
+                          Rendering style of tables.  [default: rounded-outline]
+  --verbosity LEVEL       Either CRITICAL, ERROR, WARNING, INFO, DEBUG.
+                          [default: WARNING]
+  -v, --verbose           Increase the default WARNING verbosity by one level
+                          for each additional repetition of the option.
+                          [default: 0]
+  --version               Show the version and exit.
+  -h, --help              Show this message and exit.
+
+Commands:
+  apps         List apps in the appstore
+  groups       List groups for the domain or the specified --app
+  help         Show help for a command.
+  permissions  List permissions for a given app
+  requests     List access requests
+  users        List users in Lumos
+```
+
 ### `lumos list apps`
 
 List apps available in the appstore.
+
+```ansi-shell-session
+$ lumos list --no-color apps --help
+Usage: lumos list apps [OPTIONS]
+
+  List apps in the appstore
+
+Options:
+  --like TEXT                 Filters apps by search term
+  --mine                      Show only my apps.
+  --csv                       Output as CSV
+  --json                      Output as JSON
+  --paginate / --no-paginate  Pagination  [default: paginate]
+  --page-size INTEGER         Page size  [default: 100]
+  --page INTEGER              Page  [default: 1]
+  --id-only                   Output ID only
+  -h, --help                  Show this message and exit.
+```
 
 ### `lumos list users`
 
 List users in Lumos.
 
+```ansi-shell-session
+$ lumos list --no-color users --help
+Usage: lumos list users [OPTIONS]
+
+  List users in Lumos
+
+Options:
+  --like TEXT                 Search by name or email
+  --csv                       Output as CSV
+  --json                      Output as JSON
+  --paginate / --no-paginate  Pagination  [default: paginate]
+  --page-size INTEGER         Page size  [default: 100]
+  --page INTEGER              Page  [default: 1]
+  --id-only                   Output ID only
+  -h, --help                  Show this message and exit.
+```
+
 ### `lumos list permissions`
 
 List permissions for a given app.
+
+```ansi-shell-session
+$ lumos list --no-color permissions --help
+Usage: lumos list permissions [OPTIONS]
+
+  List permissions for a given app
+
+Options:
+  --app TEXT                  App UUID  [required]
+  --like TEXT                 Filters permissions
+  --csv                       Output as CSV
+  --json                      Output as JSON
+  --paginate / --no-paginate  Pagination  [default: paginate]
+  --page-size INTEGER         Page size  [default: 100]
+  --page INTEGER              Page  [default: 1]
+  --id-only                   Output ID only
+  -h, --help                  Show this message and exit.
+```
 
 ### `lumos list groups`
 
 List groups for the domain or a specific app.
 
+```ansi-shell-session
+$ lumos list --no-color groups --help
+Usage: lumos list groups [OPTIONS]
+
+  List groups for the domain or the specified --app
+
+Options:
+  --app TEXT                  App ID to filter groups by. If not provided, lists
+                              all groups.
+  --like TEXT                 Filters groups
+  --csv                       Output as CSV
+  --json                      Output as JSON
+  --paginate / --no-paginate  Pagination  [default: paginate]
+  --page-size INTEGER         Page size  [default: 100]
+  --page INTEGER              Page  [default: 1]
+  --id-only                   Output ID only
+  -h, --help                  Show this message and exit.
+```
+
 ### `lumos list requests`
 
 List access requests.
 
+```ansi-shell-session
+$ lumos list --no-color requests --help
+Usage: lumos list requests [OPTIONS]
+
+  List access requests
+
+Options:
+  --for-user TEXT             Show only requests for ('targetting') a particular
+                              user
+  --mine                      Show only requests for ('targetting') me. Takes
+                              precedence over --for-user.
+  --status TEXT               One of `PENDING`, `COMPLETED`,
+                              `DENIED_PROVISIONING`, etc
+  --pending                   Show only pending requests
+  --past                      Show only past requests
+  --csv                       Output as CSV
+  --json                      Output as JSON
+  --paginate / --no-paginate  Pagination  [default: paginate]
+  --page-size INTEGER         Page size  [default: 100]
+  --page INTEGER              Page  [default: 1]
+  --id-only                   Output ID only
+  -h, --help                  Show this message and exit.
+```
+
 ## Request Commands
 
 The `request` command group handles access requests.
+
+```ansi-shell-session
+$ lumos --no-color request --help
+Usage: lumos request [OPTIONS] COMMAND [ARGS]...
+
+  Request access to an app.
+
+Options:
+  --reason TEXT           Business justification for request
+  --for-user TEXT         UUID of user for whom to request access. Takes
+                          precedence over --user-like
+  --for-me                Makes the request for the current user.
+  --mine                  Makes the request for the current user. Duplicate of
+                          --for-me for convenience.
+  --app TEXT              App UUID. Takes precedence over --app-like
+  --permission TEXT       List of permission UUIDs. Takes precedence over
+                          --permission-like
+  --length TEXT           Length of access request in seconds, or a string like
+                          '12 hours', '2d', 'unlimited', etc. Every
+                          app/permission has different configurations.
+  --user-like TEXT        User name/email like--filters users shown as options
+                          when selecting, if the request is not for the current
+                          user
+  --app-like TEXT         App name like--filters apps shown as options when
+                          selecting
+  --permission-like TEXT  Permission name like--filters permissions shown as
+                          options when selecting
+  --wait / --no-wait      Wait for the request to complete
+  --dry-run               Print the request command without actually making the
+                          request
+  --time / --no-time      Measure and print elapsed execution time.  [default:
+                          no-time]
+  --config CONFIG_PATH    Location of the configuration file. Supports local
+                          path with glob patterns or remote URL.  [default: ~/.c
+                          onfig/lumos/{*.toml,*.yaml,*.yml,*.json,*.ini,pyprojec
+                          t.toml}]
+  --no-config             Ignore all configuration files and only use command
+                          line parameters and environment variables.
+  --validate-config FILE  Validate the configuration file and exit.
+  --color, --ansi / --no-color, --no-ansi
+                          Strip out all colors and all ANSI codes from output.
+                          [default: color]
+  --theme [dark|dracula|light|monokai|nord|solarized_dark]
+                          Color theme used for help screens.  [default: dark]
+  --show-params           Show all CLI parameters, their provenance, defaults
+                          and value, then exit.
+  --table-format [aligned|asciidoc|colon-grid|csv|csv-excel|csv-excel-tab|csv-unix|double-grid|double-outline|fancy-grid|fancy-outline|github|grid|heavy-grid|heavy-outline|hjson|html|jira|json|json5|jsonc|latex|latex-booktabs|latex-longtable|latex-raw|mediawiki|mixed-grid|mixed-outline|moinmoin|orgtbl|outline|pipe|plain|presto|pretty|psql|rounded-grid|rounded-outline|rst|simple|simple-grid|simple-outline|textile|toml|tsv|unsafehtml|vertical|xml|yaml|youtrack]
+                          Rendering style of tables.  [default: rounded-outline]
+  --verbosity LEVEL       Either CRITICAL, ERROR, WARNING, INFO, DEBUG.
+                          [default: WARNING]
+  -v, --verbose           Increase the default WARNING verbosity by one level
+                          for each additional repetition of the option.
+                          [default: 0]
+  --version               Show the version and exit.
+  -h, --help              Show this message and exit.
+
+Commands:
+  cancel  Cancel a request by ID
+  help    Show help for a command.
+  poll    Poll a request by ID for up to 5 minutes
+  status  Check the status of a request by ID or `--last` for the most recent...
+```
 
 ### `lumos request status`
 

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -42,6 +42,10 @@ extensions = [
     "sphinx_rdme",
 ]
 
+# Required for {click:run} / {click:source} directives in docs/src/reference.md.
+# click-extra 7.10+ gates build-time CLI execution behind this opt-in flag.
+click_extra_enable_exec_directives = True
+
 # MyST Parser configuration
 myst_enable_extensions = [
     "colon_fence",

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -6,6 +6,11 @@
 import os
 import sys
 
+# Stabilize click help wrapping in generated docs across dev machines and CI.
+import click.formatting
+
+click.formatting.FORCED_WIDTH = 78
+
 # Add the source directory to the path for autodoc
 sys.path.insert(0, os.path.abspath("../../src"))
 

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -188,11 +188,11 @@ Documentation is built using [Sphinx](https://www.sphinx-doc.org/) with [MyST Ma
 uv sync --group docs
 
 # Build both HTML and Markdown, copy markdown to docs/
-make -C docs docs
+make docs
 
 # Or build individually:
-make -C docs html      # HTML only
-make -C docs markdown  # Markdown only
+make html      # HTML only
+make markdown  # Markdown only
 
 # View the HTML docs
 open docs/src/_build/html/index.html

--- a/docs/src/contributing.md
+++ b/docs/src/contributing.md
@@ -275,7 +275,7 @@ uv version X.Y.Z
 
 # Build artifacts
 uv build
-uv run pyinstaller src/lumos/__main__.py
+uv run pyinstaller src/lumos/__main__.py --collect-data click_extra
 
 # Create and push tag
 git tag vX.Y.Z

--- a/docs/src/installation.md
+++ b/docs/src/installation.md
@@ -21,13 +21,19 @@ brew install teamlumos/tap/lumos
 
 This installs a native binary with no Python dependencies required.
 
-## Python (PyPI)
+## Python (via PyPI)
 
-Install from PyPI when you want the Python package:
+Install the CLI from [PyPI](https://pypi.org/project/lumos-identity-cli/) with pip or uv:
 
 ```bash
 pip install lumos-identity-cli
 ```
+
+```bash
+uv tool install lumos-identity-cli
+```
+
+Requires Python 3.10.6 or newer. After installation, run `lumos --version` to verify.
 
 ### Supported Platforms
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
 ]
 dependencies = [
-    "click-extra>=7.4.0,<8",
+    "click-extra>=7.10.0,<8",
     "pick>=2.2.0,<3",
     "pydantic>=2.6.0,<3",
     "pytz>=2024.1",

--- a/src/lumos/cli.py
+++ b/src/lumos/cli.py
@@ -15,7 +15,7 @@ client = ApiClient()
 
 @group(
     context_settings={"help_option_names": ["-h", "--help"]},
-    version=__version__,
+    version_fields={"version": __version__},
 )
 @option("--debug", is_flag=True, help="Enable debug mode", hidden=True)
 @pass_context

--- a/tests/cli_test.py
+++ b/tests/cli_test.py
@@ -5,6 +5,7 @@ These tests validate the end-user experience by testing CLI structure,
 options, and help text without making actual API calls.
 """
 
+import os
 from unittest.mock import patch
 from uuid import UUID
 
@@ -84,7 +85,11 @@ def mock_access_request(mock_user, mock_app, mock_permission):
 
 @pytest.fixture
 def runner():
-    return CliRunner()
+    # GitHub Actions sets FORCE_COLOR=1; click-extra 7.10+ then highlights help
+    # keywords with ANSI codes, which breaks plain-string assertions.
+    env = os.environ.copy()
+    env["FORCE_COLOR"] = "0"
+    return CliRunner(env=env)
 
 
 class TestMainCLI:

--- a/uv.lock
+++ b/uv.lock
@@ -365,7 +365,7 @@ wheels = [
 
 [[package]]
 name = "lumos-identity-cli"
-version = "2.3.0"
+version = "2.4.1"
 source = { editable = "." }
 dependencies = [
     { name = "click-extra" },

--- a/uv.lock
+++ b/uv.lock
@@ -189,7 +189,7 @@ wheels = [
 
 [[package]]
 name = "click-extra"
-version = "7.4.0"
+version = "7.16.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "boltons" },
@@ -202,9 +202,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "wcmatch" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/2a/79e85d7683fd97037326dbdad60524c075ef01dad2adad0a6d6fa40c41a4/click_extra-7.4.0.tar.gz", hash = "sha256:869cd811074a4c5049fb241087e55242bf36ee328133ae932f37730833d9b9d9", size = 86763, upload-time = "2025-12-08T05:06:28.587Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/02/d180104019150d340049dccc41f17d9ba0c3363c44767b01b029716d259b/click_extra-7.16.1.tar.gz", hash = "sha256:a616651275a9673ed4930976a1d6bdd93dc04325cf475ccc38399b0c4396644e", size = 190154, upload-time = "2026-05-15T06:53:28.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5f/8e/61d484461ead9f2c971ba11a9ee591aed0c0e707b2e4ac28ddc26e65e486/click_extra-7.4.0-py3-none-any.whl", hash = "sha256:f827066818b8f41e83189793e64dcd67425b228f62332597e02d3ec9cf4711b5", size = 102505, upload-time = "2025-12-08T05:06:27.164Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/91/81c0dacf90bc8d9f778ef74e3993cad0e7c99647afd7352a6e9769c0398c/click_extra-7.16.1-py3-none-any.whl", hash = "sha256:d83cb123f82f13d95bc5d0ffa3d049c3bcdb55278105d0a77059eb0735e9286e", size = 208248, upload-time = "2026-05-15T06:53:26.535Z" },
 ]
 
 [[package]]
@@ -277,15 +277,6 @@ wheels = [
 ]
 
 [[package]]
-name = "distro"
-version = "1.9.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
-]
-
-[[package]]
 name = "docutils"
 version = "0.20.1"
 source = { registry = "https://pypi.org/simple" }
@@ -308,14 +299,11 @@ wheels = [
 
 [[package]]
 name = "extra-platforms"
-version = "6.0.0"
+version = "12.0.3"
 source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "distro" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fb/df/73e313d4ecca7b703b6f369d9ed0c2c0d4d8a149e1c675e9915f8426a513/extra_platforms-6.0.0.tar.gz", hash = "sha256:ff0d392e390d2447183af4b300dd4569d2dbf760adf1e30c2b0cefb30ee58488", size = 45977, upload-time = "2026-01-02T09:15:41.019Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4c/f6/a20c4586c9bd653f596258455652725405f4b734e6270f7fc07a1a498932/extra_platforms-12.0.3.tar.gz", hash = "sha256:0a3201a05f93f18c840f3e9970d33f756a621eea719cbdfa24a514f96c79de7e", size = 72879, upload-time = "2026-04-29T06:47:18.131Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/99/13/0a6a20bd85679d30d8e85d4e63397f8deabe2e9614d6a656ad3e02a76fb7/extra_platforms-6.0.0-py3-none-any.whl", hash = "sha256:732619d1f7db602e12189a66a7de7d8492607452c2d1b5444952174e92864ed0", size = 53001, upload-time = "2026-01-02T09:15:42.193Z" },
+    { url = "https://files.pythonhosted.org/packages/46/ef/efc376476f41868ca834b30ed100b250d53da2b4929ee8e63ef48e7b0b03/extra_platforms-12.0.3-py3-none-any.whl", hash = "sha256:b6b7fad4b41e1f9f161cc74c03d963e43a3a34e0ee1991943314685314b01cf6", size = 76128, upload-time = "2026-04-29T06:47:16.945Z" },
 ]
 
 [[package]]
@@ -413,7 +401,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
-    { name = "click-extra", specifier = ">=7.4.0,<8" },
+    { name = "click-extra", specifier = ">=7.10.0,<8" },
     { name = "pick", specifier = ">=2.2.0,<3" },
     { name = "pydantic", specifier = ">=2.6.0,<3" },
     { name = "pytz", specifier = ">=2024.1" },


### PR DESCRIPTION
## Summary

- Replace deprecated `version=` on `@group()` with `version_fields={"version": __version__}` for click-extra 7.10+
- Raise minimum `click-extra` dependency to `>=7.10.0,<8` so pip resolves a compatible release
- Update `uv.lock` to click-extra 7.16.1

Fixes PyPI installs failing at import time with `TypeError: Command.__init__() got an unexpected keyword argument 'version'`. Dev used click-extra 7.4.0 (lockfile) while pip installed 7.16.x.

## Test plan

- [ ] `uv run lumos --version` prints version without error
- [ ] `uv run pytest tests/cli_test.py -k test_cli_version`
- [ ] Fresh venv: `pip install lumos-identity-cli` (after PyPI release) and run `lumos --version`

Made with [Cursor](https://cursor.com)